### PR TITLE
Tweak Gradient2 algorithm

### DIFF
--- a/limit/gradient2_test.go
+++ b/limit/gradient2_test.go
@@ -17,8 +17,8 @@ func TestGradient2Limit(t *testing.T) {
 		l := NewDefaultGradient2Limit("test", nil, nil)
 		asrt.NotNil(l)
 
-		asrt.Equal(4, l.EstimatedLimit())
-		asrt.Equal("Gradient2Limit{limit=4}", l.String())
+		asrt.Equal(20, l.EstimatedLimit())
+		asrt.Equal("Gradient2Limit{limit=20}", l.String())
 	})
 
 	t.Run("OnSample", func(t2 *testing.T) {

--- a/limit/gradient2_test.go
+++ b/limit/gradient2_test.go
@@ -32,9 +32,6 @@ func TestGradient2Limit(t *testing.T) {
 			nil,
 			-1,
 			-1,
-			-1,
-			-1,
-			nil,
 			NoopLimitLogger{},
 			core.EmptyMetricRegistryInstance,
 		)
@@ -47,30 +44,30 @@ func TestGradient2Limit(t *testing.T) {
 		l.OnSample(0, 10, 1, false)
 		asrt.Equal(50, l.EstimatedLimit())
 
-		for i := 0; i < 51; i++ {
-			l.OnSample(int64(i), 100, 1, false)
+		for i := 0; i < 25; i++ {
+			l.OnSample(int64(i), 10*int64(i), i, false)
 			asrt.Equal(50, l.EstimatedLimit())
 		}
 
 		// dropped samples cut off limit, smoothed down
-		l.OnSample(60, 100, 1, true)
-		asrt.Equal(4, l.EstimatedLimit())
-		asrt.Equal(4, listener.changes[0])
+		l.OnSample(25, 2500, 25, true)
+		asrt.Equal(45, l.EstimatedLimit())
+		asrt.Equal(45, listener.changes[0])
 
 		// test new sample shouldn't grow too fast
-		l.OnSample(20, 10, 5, false)
-		asrt.Equal(6, l.EstimatedLimit())
+		l.OnSample(26, 10, 5, false)
+		asrt.Equal(45, l.EstimatedLimit())
 
 		// drain down again
 		for i := 0; i < 100; i++ {
-			l.OnSample(int64(i*10+30), 10, 1, true)
+			l.OnSample(int64(i+27), 1000, i, true)
 		}
-		asrt.Equal(6, l.EstimatedLimit())
+		asrt.Equal(21, l.EstimatedLimit())
 
 		// slowly grow back up
 		for i := 0; i < 100; i++ {
-			l.OnSample(int64(i*10+3030), 1, 5, false)
+			l.OnSample(int64(i+127), 1, 1, false)
 		}
-		asrt.Equal(13, l.EstimatedLimit())
+		asrt.Equal(21, l.EstimatedLimit())
 	})
 }

--- a/measurements/exponential_average_test.go
+++ b/measurements/exponential_average_test.go
@@ -9,21 +9,21 @@ import (
 func TestExponentialAverageMeasurement(t *testing.T) {
 	t.Parallel()
 	asrt := assert.New(t)
-	m := NewExponentialAverageMeasurement(100, 10, nil)
+	m := NewExponentialAverageMeasurement(100, 10)
 
-	expected := []float64{10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
+	expected := []float64{10, 10.5, 11, 11.5, 12, 12.5, 13, 13.5, 14, 14.5}
 	for i := 0; i < 10; i++ {
 		result, _ := m.Add(float64(i + 10))
 		asrt.Equal(expected[i], result)
 	}
 
 	m.Add(100)
-	asrt.InDelta(float64(11.78), m.Get(), 0.01)
+	asrt.InDelta(float64(16.2), m.Get(), 0.01)
 
 	m.Update(func(value float64) float64 {
 		return value - 1
 	})
-	asrt.InDelta(float64(10.78), m.Get(), 0.01)
+	asrt.InDelta(float64(15.19), m.Get(), 0.01)
 
 	m.Reset()
 	asrt.Equal(float64(0), m.Get())


### PR DESCRIPTION
port over changes from https://github.com/Netflix/concurrency-limits/pull/92

> better defaults
> more stable long term RTT
> Simpler mechanism to reduce RTT when a system goes back to steady state
