### PR TITLE
Fix build for go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.48/hugo_0.48_Linux-64bit.deb
   - sudo dpkg -i hugo_0.48_Linux-64bit.deb
 language: go
-go:
-  - "1.10"
-  - "1.11"
-  - "1.12"
 deploy:
   provider: pages
   skip-cleanup: true
@@ -20,15 +16,38 @@ deploy:
   local-dir: docs
 env:
   - TEST_PACKAGES='./core ./grpc ./limit ./limit/functions ./limiter ./measurements ./strategy ./strategy/matchers ./metric_registry/datadog ./metric_registry/gometrics ./examples/example_simple_limit ./examples/example_blocking_limit'
-before_script:
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mattn/goveralls
-  - go get golang.org/x/lint/golint
-  - go get github.com/golang/dep/cmd/dep
-  - dep ensure -v
-  - go fmt $TEST_PACKAGES
-  - golint $TEST_PACKAGES
-  - go vet -shadowstrict $TEST_PACKAGES
+matrix:
+  include:
+  - go: "1.10"
+    before_script:
+      - go get golang.org/x/tools/cmd/cover
+      - go get github.com/mattn/goveralls
+      - go get golang.org/x/lint/golint
+      - go get github.com/golang/dep/cmd/dep
+      - dep ensure -v
+      - go fmt $TEST_PACKAGES
+      - golint $TEST_PACKAGES
+      - go vet -shadowstrict $TEST_PACKAGES
+  - go: "1.11"
+    before_script:
+      - go get golang.org/x/tools/cmd/cover
+      - go get github.com/mattn/goveralls
+      - go get golang.org/x/lint/golint
+      - go get github.com/golang/dep/cmd/dep
+      - dep ensure -v
+      - go fmt $TEST_PACKAGES
+      - golint $TEST_PACKAGES
+      - go vet -shadowstrict $TEST_PACKAGES
+  - go: "1.12"
+    before_script:
+      - go get golang.org/x/tools/cmd/cover
+      - go get github.com/mattn/goveralls
+      - go get golang.org/x/lint/golint
+      - go get github.com/golang/dep/cmd/dep
+      - dep ensure -v
+      - go fmt $TEST_PACKAGES
+      - golint $TEST_PACKAGES
+      - go vet $TEST_PACKAGES
 script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.out $TEST_PACKAGES
   - $(go env GOPATH | awk 'BEGIN{FS=":"} {print $1}')/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=${COVERALLS_TOKEN}


### PR DESCRIPTION
some issues with `go vet` that now require a build matrix... to keep testing go 1.10 && 1.11