### PR TITLE
Fix bugs around Log10RootFunction

### DIFF
--- a/limit/functions/log10_root.go
+++ b/limit/functions/log10_root.go
@@ -14,7 +14,7 @@ func Log10RootFunction(baseline int) func(estimatedLimit int) int {
 		if estimatedLimit < len(log10RootLookup) {
 			return max(baseline, log10RootLookup[estimatedLimit])
 		}
-		return max(baseline, int(math.Sqrt(float64(estimatedLimit))))
+		return max(baseline, int(math.Log10(float64(estimatedLimit))))
 	}
 }
 

--- a/limit/functions/log10_root.go
+++ b/limit/functions/log10_root.go
@@ -12,9 +12,9 @@ var log10RootLookup []int
 func Log10RootFunction(baseline int) func(estimatedLimit int) int {
 	return func(estimatedLimit int) int {
 		if estimatedLimit < len(log10RootLookup) {
-			return max(baseline, log10RootLookup[estimatedLimit])
+			return baseline + log10RootLookup[estimatedLimit]
 		}
-		return max(baseline, int(math.Log10(float64(estimatedLimit))))
+		return baseline + int(math.Log10(float64(estimatedLimit)))
 	}
 }
 
@@ -24,8 +24,8 @@ func Log10RootFunction(baseline int) func(estimatedLimit int) int {
 func Log10RootFloatFunction(baseline float64) func(estimatedLimit float64) float64 {
 	return func(estimatedLimit float64) float64 {
 		if int(estimatedLimit) < len(log10RootLookup) {
-			return math.Max(baseline, float64(log10RootLookup[int(estimatedLimit)]))
+			return baseline + float64(log10RootLookup[int(estimatedLimit)])
 		}
-		return math.Max(baseline, math.Sqrt(estimatedLimit))
+		return baseline + math.Log10(estimatedLimit)
 	}
 }

--- a/limit/functions/log10_root_test.go
+++ b/limit/functions/log10_root_test.go
@@ -12,19 +12,19 @@ func TestLog10RootFunction(t *testing.T) {
 	t.Run("ZeroIndex", func(t2 *testing.T) {
 		t2.Parallel()
 		f := Log10RootFunction(4)
-		assert.Equal(t2, 4, f(0))
+		assert.Equal(t2, 5, f(0))
 	})
 
 	t.Run("MaxIndex", func(t2 *testing.T) {
 		t2.Parallel()
 		f := Log10RootFunction(4)
-		assert.Equal(t2, 31, f(1000))
+		assert.Equal(t2, 7, f(1000))
 	})
 
 	t.Run("OutOfLookupRange", func(t2 *testing.T) {
 		t2.Parallel()
 		f := Log10RootFunction(4)
-		assert.Equal(t2, 50, f(2500))
+		assert.Equal(t2, 7, f(2500))
 	})
 }
 
@@ -34,18 +34,18 @@ func TestLog10RootFloatFunction(t *testing.T) {
 	t.Run("ZeroIndex", func(t2 *testing.T) {
 		t2.Parallel()
 		f := Log10RootFloatFunction(4)
-		assert.Equal(t2, 4.0, f(0))
+		assert.Equal(t2, 5.0, f(0))
 	})
 
 	t.Run("MaxIndex", func(t2 *testing.T) {
 		t2.Parallel()
 		f := Log10RootFloatFunction(4)
-		assert.InDelta(t2, 31.623, f(1000), 0.001)
+		assert.InDelta(t2, 7.0, f(1000), 0.001)
 	})
 
 	t.Run("OutOfLookupRange", func(t2 *testing.T) {
 		t2.Parallel()
 		f := Log10RootFloatFunction(4)
-		assert.Equal(t2, 50.0, f(2500))
+		assert.Equal(t2, 7.3979400086720375, f(2500))
 	})
 }


### PR DESCRIPTION
I seem there is mistake.
I wrote this PR.

In the initialization for `log10RootLookup`, `Log10` is used,
But, `Sqrt` is used if `log10RootLookup` does not have.
This is mistake?

I found that Log10RootFunction differs from [original](https://github.com/Netflix/concurrency-limits/blob/master/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/functions/Log10RootFunction.java#L41) too. 