### PR TITLE
Reduce struct size in metric_registry

### DIFF
--- a/metric_registry/datadog/registry.go
+++ b/metric_registry/datadog/registry.go
@@ -54,10 +54,11 @@ type MetricRegistry struct {
 	registeredGauges    map[string]*metricPoller
 	registeredListeners map[string]*metricSampleListener
 
+	mu sync.Mutex
+	wg sync.WaitGroup
+
 	started bool
 	stopper chan bool
-	mu      sync.Mutex
-	wg      sync.WaitGroup
 }
 
 // NewMetricRegistry will create a new Datadog MetricRegistry.

--- a/metric_registry/gometrics/registry.go
+++ b/metric_registry/gometrics/registry.go
@@ -57,10 +57,11 @@ type MetricRegistry struct {
 	registeredGauges    map[string]*gometricsMetricPoller
 	registeredListeners map[string]*metricSampleListener
 
+	mu sync.Mutex
+	wg sync.WaitGroup
+
 	started bool
 	stopper chan bool
-	mu      sync.Mutex
-	wg      sync.WaitGroup
 }
 
 // NewGoMetricsMetricRegistry will create a new Datadog MetricRegistry.


### PR DESCRIPTION
Reduce struct size in metric_registry

```bash
$ golangci-lint version
golangci-lint has version 1.31.0 built from 3d6d0e7 on 2020-09-07T15:14:41Z
$ golangci-lint run --disable-all --enable maligned
metric_registry/gometrics/registry.go:53:21: struct of size 96 bytes could be of size 88 bytes (maligned)
type MetricRegistry struct {
                    ^
metric_registry/datadog/registry.go:50:21: struct of size 88 bytes could be of size 80 bytes (maligned)
type MetricRegistry struct {

```