### PR TITLE
bugfix for lifo queue nil pointer

### DIFF
--- a/limiter/lifo_blocking.go
+++ b/limiter/lifo_blocking.go
@@ -106,12 +106,13 @@ func (q *lifoQueue) remove(id uint64) {
 				q.top.next = nil
 				q.top.prev = nil
 				q.top = next
-				q.top.id--
 				q.size--
 				return
 			}
-			next.prev = prev
-			prev.next = cur.next
+			if next != nil {
+				next.prev = nil
+			}
+			prev.next = next
 			q.size--
 			return
 

--- a/limiter/lifo_blocking_test.go
+++ b/limiter/lifo_blocking_test.go
@@ -123,6 +123,14 @@ func TestLifoQueue_Remove(t *testing.T) {
 	}
 	asrt.Equal(uint64(0), q.len())
 	asrt.Equal(7, len(seenElements))
+
+	q = lifoQueue{}
+	ctx = context.WithValue(context.Background(), testLifoQueueContextKey(1), 1)
+	q.push(ctx)
+
+	// Remove very last item leaving queue empty
+	q.remove(1)
+	asrt.Equal(uint64(0), q.len())
 }
 
 func TestLifoBlockingListener(t *testing.T) {

--- a/limiter/lifo_blocking_test.go
+++ b/limiter/lifo_blocking_test.go
@@ -82,6 +82,49 @@ func TestLifoQueue(t *testing.T) {
 	}
 }
 
+func TestLifoQueue_Remove(t *testing.T) {
+	t.Parallel()
+	asrt := assert.New(t)
+	q := lifoQueue{}
+
+	asrt.Equal(uint64(0), q.len())
+	size, ctx := q.peek()
+	asrt.Equal(uint64(0), size)
+	asrt.Nil(ctx)
+	asrt.Nil(q.pop())
+
+	for i := 1; i <= 10; i++ {
+		ctx := context.WithValue(context.Background(), testLifoQueueContextKey(i), i)
+		q.push(ctx)
+	}
+
+	// remove last
+	q.remove(1)
+	asrt.Equal(uint64(9), q.len())
+
+	// remove first
+	q.remove(q.len())
+	asrt.Equal(uint64(8), q.len())
+
+	// remove middle
+	q.remove(q.len() / 2)
+	asrt.Equal(uint64(7), q.len())
+
+	seenElements := make(map[uint64]struct{}, q.len())
+	var element *lifoElement
+	for {
+		element = q.pop()
+		if element == nil {
+			break
+		}
+		_, seen := seenElements[element.id]
+		asrt.False(seen, "no duplicate element ids allowed")
+		seenElements[element.id] = struct{}{}
+	}
+	asrt.Equal(uint64(0), q.len())
+	asrt.Equal(7, len(seenElements))
+}
+
 func TestLifoBlockingListener(t *testing.T) {
 	t.Parallel()
 	delegateLimiter, _ := NewDefaultLimiterWithDefaults(


### PR DESCRIPTION
@platinummonkey 

I've run into two issues with when testing out the lifo queue implementation.
* If you try to remove the last element in the queue line 114 would produce a nil pointer.
* If you try to remove the first element in the queue line 109 would cause duplicate element ids to occur. Looking at the implementation for pop, youll see the element id is never decremented. 

Tests covering the changes have been added