### PR TITLE
Queue impl parity

### DIFF
--- a/core/dep.go
+++ b/core/dep.go
@@ -25,6 +25,11 @@ const (
 	MetricLifoQueueSize = "lifo.queue_size"
 	// MetricLifoQueueLimit represents the name of the metric for the max size of a lifo queue
 	MetricLifoQueueLimit = "lifo.queue_limit"
+
+	// MetricQueueSize represents the name of the metric for the size of a lifo queue
+	MetricQueueSize = "queue_size"
+	// MetricQueueLimit represents the name of the metric for the max size of a lifo queue
+	MetricQueueLimit = "queue_limit"
 )
 
 // PrefixMetricWithName will prefix a given name with the metric name in the form "<name>.<metric>"

--- a/core/dep.go
+++ b/core/dep.go
@@ -21,11 +21,6 @@ const (
 	MetricWindowMinRTT = "window.min_rtt"
 	// MetricWindowQueueSize represents the name of the metric for the Window's Queue Size
 	MetricWindowQueueSize = "window.queue_size"
-	// MetricLifoQueueSize represents the name of the metric for the size of a lifo queue
-	MetricLifoQueueSize = "lifo.queue_size"
-	// MetricLifoQueueLimit represents the name of the metric for the max size of a lifo queue
-	MetricLifoQueueLimit = "lifo.queue_limit"
-
 	// MetricQueueSize represents the name of the metric for the size of a lifo queue
 	MetricQueueSize = "queue_size"
 	// MetricQueueLimit represents the name of the metric for the max size of a lifo queue

--- a/limit/aimd.go
+++ b/limit/aimd.go
@@ -88,7 +88,7 @@ func (l *AIMDLimit) OnSample(startTime int64, rtt int64, inFlight int, didDrop b
 	l.commonSampler.Sample(rtt, inFlight, didDrop)
 
 	if didDrop {
-		l.limit = int(math.Max(1, math.Min(float64(l.limit-1), float64(int(float64(l.limit)*l.backOffRatio)))))
+		l.limit = int(math.Max(1, math.Min(float64(l.limit-1), float64(l.limit)*l.backOffRatio)))
 		l.notifyListeners(l.limit)
 	} else if inFlight >= l.limit {
 		l.limit += l.increaseBy

--- a/limiter/fifo_blocking.go
+++ b/limiter/fifo_blocking.go
@@ -1,127 +1,10 @@
 package limiter
 
 import (
-	"container/list"
-	"context"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/platinummonkey/go-concurrency-limits/core"
 )
-
-type fifoElement struct {
-	ctx         context.Context
-	releaseChan chan core.Listener
-}
-
-func (e *fifoElement) setListener(listener core.Listener) {
-	select {
-	case e.releaseChan <- listener:
-		// noop
-	default:
-		// timeout has expired
-	}
-}
-
-type fifoQueue struct {
-	q  *list.List
-	mu sync.RWMutex
-}
-
-func (q *fifoQueue) len() int {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	return q.q.Len()
-}
-
-func (q *fifoQueue) push(ctx context.Context) (*list.Element, chan core.Listener) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	releaseChan := make(chan core.Listener, 1)
-	fe := fifoElement{
-		ctx:         ctx,
-		releaseChan: releaseChan,
-	}
-	e := q.q.PushBack(fe)
-	return e, releaseChan
-}
-
-func (q *fifoQueue) pop() *fifoElement {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	e := q.q.Front()
-	if e != nil {
-		fe := e.Value.(fifoElement)
-		q.q.Remove(e)
-		return &fe
-	}
-	return nil
-}
-
-func (q *fifoQueue) peek() *fifoElement {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	e := q.q.Front()
-	if e != nil {
-		fe := q.q.Front().Value.(fifoElement)
-		return &fe
-	}
-	return nil
-}
-
-func (q *fifoQueue) remove(event *list.Element) {
-	if event == nil {
-		return
-	}
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.q.Remove(event)
-}
-
-// FifoBlockingListener implements a blocking listener for the FifoBlockingListener
-type FifoBlockingListener struct {
-	delegateListener core.Listener
-	limiter          *FifoBlockingLimiter
-}
-
-func (l *FifoBlockingListener) unblock() {
-	l.limiter.mu.Lock()
-	defer l.limiter.mu.Unlock()
-	if l.limiter.backlog.len() > 0 {
-		event := l.limiter.backlog.peek()
-		if event != nil {
-			listener, ok := l.limiter.delegate.Acquire(event.ctx)
-			if ok && listener != nil {
-				nextEvent := l.limiter.backlog.pop()
-				nextEvent.setListener(listener)
-			}
-		}
-		// otherwise: still can't acquire the limit.  unblock will be called again next time the limit is released.
-	}
-}
-
-// OnDropped is called to indicate the request failed and was dropped due to being rejected by an external limit or
-// hitting a timeout.  Loss based Limit implementations will likely do an aggressive reducing in limit when this
-// happens.
-func (l *FifoBlockingListener) OnDropped() {
-	l.delegateListener.OnDropped()
-	l.unblock()
-}
-
-// OnIgnore is called to indicate the operation failed before any meaningful RTT measurement could be made and
-// should be ignored to not introduce an artificially low RTT.
-func (l *FifoBlockingListener) OnIgnore() {
-	l.delegateListener.OnIgnore()
-	l.unblock()
-}
-
-// OnSuccess is called as a notification that the operation succeeded and internally measured latency should be
-// used as an RTT sample.
-func (l *FifoBlockingListener) OnSuccess() {
-	l.delegateListener.OnSuccess()
-	l.unblock()
-}
 
 // FifoBlockingLimiter implements a Limiter that blocks the caller when the limit has been reached.  This strategy
 // ensures the resource is properly protected but favors availability over latency by not fast failing requests when
@@ -129,90 +12,32 @@ func (l *FifoBlockingListener) OnSuccess() {
 // processed in last in/first out order.
 //
 // Use this limiter only when the concurrency model allows the limiter to be blocked.
+// Deprecated in favor of QueueBlockingLimiter
 type FifoBlockingLimiter struct {
-	delegate          core.Limiter
-	maxBacklogSize    int
-	maxBacklogTimeout time.Duration
-
-	backlog fifoQueue
-	c       *sync.Cond
-	mu      sync.RWMutex
+	*QueueBlockingLimiter
 }
 
 // NewFifoBlockingLimiter will create a new FifoBlockingLimiter
+// Deprecated, use NewQueueBlockingLimiterFromConfig instead
 func NewFifoBlockingLimiter(
 	delegate core.Limiter,
 	maxBacklogSize int,
 	maxBacklogTimeout time.Duration,
 ) *FifoBlockingLimiter {
-	if maxBacklogSize <= 0 {
-		maxBacklogSize = 100
-	}
-	if maxBacklogTimeout == 0 {
-		maxBacklogTimeout = time.Millisecond * 1000
-	}
-	mu := sync.Mutex{}
+
 	return &FifoBlockingLimiter{
-		delegate:          delegate,
-		maxBacklogSize:    maxBacklogSize,
-		maxBacklogTimeout: maxBacklogTimeout,
-		backlog: fifoQueue{
-			q: list.New(),
-		},
-		c: sync.NewCond(&mu),
+		NewQueueBlockingLimiterFromConfig(delegate, QueueLimiterConfig{
+			Ordering:          OrderingFIFO,
+			MaxBacklogSize:    maxBacklogSize,
+			MaxBacklogTimeout: maxBacklogTimeout,
+		}),
 	}
 }
 
 // NewFifoBlockingLimiterWithDefaults will create a new FifoBlockingLimiter with default values.
+// Deprecated, use NewQueueBlockingLimiterWithDefaults instead
 func NewFifoBlockingLimiterWithDefaults(
 	delegate core.Limiter,
 ) *FifoBlockingLimiter {
 	return NewFifoBlockingLimiter(delegate, 100, time.Millisecond*1000)
-}
-
-func (l *FifoBlockingLimiter) tryAcquire(ctx context.Context) core.Listener {
-	// Try to acquire a token and return immediately if successful
-	listener, ok := l.delegate.Acquire(ctx)
-	if ok && listener != nil {
-		return listener
-	}
-
-	// Restrict backlog size so the queue doesn't grow unbounded during an outage
-	if l.backlog.len() >= l.maxBacklogSize {
-		return nil
-	}
-
-	// Create a holder for a listener and block until a listener is released by another
-	// operation.  Holders will be unblocked in FIFO order
-	event, eventReleaseChan := l.backlog.push(ctx)
-	select {
-	case listener = <-eventReleaseChan:
-		return listener
-	case <-time.After(l.maxBacklogTimeout):
-		// Remove the holder from the backlog.  This item is likely to be at the end of the
-		// list so do a remove to minimize the number of items to traverse
-		l.backlog.remove(event)
-		return nil
-	}
-}
-
-// Acquire a token from the limiter.  Returns an Optional.empty() if the limit has been exceeded.
-// If acquired the caller must call one of the Listener methods when the operation has been completed to release
-// the count.
-//
-// context Context for the request. The context is used by advanced strategies such as LookupPartitionStrategy.
-func (l *FifoBlockingLimiter) Acquire(ctx context.Context) (core.Listener, bool) {
-	delegateListener := l.tryAcquire(ctx)
-	if delegateListener == nil {
-		return nil, false
-	}
-	return &FifoBlockingListener{
-		delegateListener: delegateListener,
-		limiter:          l,
-	}, true
-}
-
-func (l *FifoBlockingLimiter) String() string {
-	return fmt.Sprintf("FifoBlockingLimiter{delegate=%v, maxBacklogSize=%d, maxBacklogTimeout=%v}",
-		l.delegate, l.maxBacklogSize, l.maxBacklogTimeout)
 }

--- a/limiter/fifo_blocking_test.go
+++ b/limiter/fifo_blocking_test.go
@@ -1,7 +1,6 @@
 package limiter
 
 import (
-	"container/list"
 	"context"
 	"strings"
 	"sync"
@@ -13,81 +12,6 @@ import (
 	"github.com/platinummonkey/go-concurrency-limits/limit"
 	"github.com/platinummonkey/go-concurrency-limits/strategy"
 )
-
-func TestFifoQueue(t *testing.T) {
-	t.Parallel()
-	asrt := assert.New(t)
-	q := fifoQueue{
-		q: list.New(),
-	}
-
-	asrt.Equal(0, q.len())
-	el := q.peek()
-	asrt.Nil(el)
-	asrt.Nil(q.pop())
-
-	ctx1 := context.WithValue(context.Background(), testFifoQueueContextKey(1), 1)
-	q.push(ctx1)
-
-	el = q.peek()
-	asrt.Equal(1, q.len())
-	asrt.NotNil(el)
-	asrt.Equal(ctx1, el.ctx)
-
-	// add a 2nd
-	ctx2 := context.WithValue(context.Background(), testFifoQueueContextKey(2), 2)
-	q.push(ctx2)
-
-	// make sure it's still FIFO
-	el = q.peek()
-	asrt.Equal(2, q.len())
-	asrt.NotNil(el)
-	asrt.Equal(ctx1, el.ctx)
-
-	// pop off
-	el = q.pop()
-	asrt.NotNil(el)
-	asrt.Equal(ctx1, el.ctx)
-
-	// check that we only have one again
-	el = q.peek()
-	asrt.Equal(1, q.len())
-	asrt.NotNil(el)
-	asrt.Equal(ctx2, el.ctx)
-
-	// add a 2nd & 3rd
-	ctx3 := context.WithValue(context.Background(), testFifoQueueContextKey(3), 3)
-	el3, _ := q.push(ctx3)
-	ctx4 := context.WithValue(context.Background(), testFifoQueueContextKey(4), 4)
-	q.push(ctx4)
-
-	// remove the middle
-	q.remove(el3)
-	el = q.peek()
-	asrt.Equal(2, q.len())
-	asrt.NotNil(el)
-	asrt.Equal(ctx2, el.ctx)
-	asrt.Equal(ctx4, q.q.Back().Value.(fifoElement).ctx)
-}
-
-func TestFifoBlockingListener(t *testing.T) {
-	t.Parallel()
-	delegateLimiter, _ := NewDefaultLimiterWithDefaults(
-		"",
-		strategy.NewSimpleStrategy(20),
-		limit.NoopLimitLogger{},
-		core.EmptyMetricRegistryInstance,
-	)
-	limiter := NewFifoBlockingLimiterWithDefaults(delegateLimiter)
-	delegateListener, _ := delegateLimiter.Acquire(context.Background())
-	listener := FifoBlockingListener{
-		delegateListener: delegateListener,
-		limiter:          limiter,
-	}
-	listener.OnSuccess()
-	listener.OnIgnore()
-	listener.OnDropped()
-}
 
 func TestFifoBlockingLimiter(t *testing.T) {
 	t.Parallel()
@@ -103,7 +27,7 @@ func TestFifoBlockingLimiter(t *testing.T) {
 		)
 		limiter := NewFifoBlockingLimiterWithDefaults(delegateLimiter)
 		asrt.NotNil(limiter)
-		asrt.True(strings.Contains(limiter.String(), "FifoBlockingLimiter{delegate=DefaultLimiter{"))
+		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
 	})
 
 	t.Run("NewFifoBlockingLimiter", func(t2 *testing.T) {
@@ -117,7 +41,7 @@ func TestFifoBlockingLimiter(t *testing.T) {
 		)
 		limiter := NewFifoBlockingLimiter(delegateLimiter, -1, 0)
 		asrt.NotNil(limiter)
-		asrt.True(strings.Contains(limiter.String(), "FifoBlockingLimiter{delegate=DefaultLimiter{"))
+		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
 	})
 
 	t.Run("Acquire", func(t2 *testing.T) {

--- a/limiter/fifo_blocking_test.go
+++ b/limiter/fifo_blocking_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/platinummonkey/go-concurrency-limits/strategy"
 )
 
-type testFifoQueueContextKey int
-
 func TestFifoQueue(t *testing.T) {
 	t.Parallel()
 	asrt := assert.New(t)
@@ -89,11 +87,6 @@ func TestFifoBlockingListener(t *testing.T) {
 	listener.OnSuccess()
 	listener.OnIgnore()
 	listener.OnDropped()
-}
-
-type acquiredListenerFifo struct {
-	id       int
-	listener core.Listener
 }
 
 func TestFifoBlockingLimiter(t *testing.T) {

--- a/limiter/lifo_blocking.go
+++ b/limiter/lifo_blocking.go
@@ -1,170 +1,10 @@
 package limiter
 
 import (
-	"context"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/platinummonkey/go-concurrency-limits/core"
 )
-
-type lifoElement struct {
-	ctx         context.Context
-	releaseChan chan<- core.Listener
-	next, prev  *lifoElement
-	evicted     bool
-}
-
-func (e *lifoElement) setListener(listener core.Listener) bool {
-	select {
-	case e.releaseChan <- listener:
-		close(e.releaseChan)
-		return true
-	default:
-		// timeout has expired
-		return false
-	}
-}
-
-func (q *lifoQueue) evictionFunc(e *lifoElement) func() {
-	return func() {
-		q.mu.Lock()
-		defer q.mu.Unlock()
-
-		// Prevent multiple invocations from
-		// corrupting the queue state.
-		if e.evicted {
-			return
-		}
-
-		e.evicted = true
-
-		if e.prev == nil {
-			q.top = e.next
-		} else {
-			e.prev.next = e.next
-		}
-		if e.next != nil {
-			e.next.prev = e.prev
-		}
-		q.size--
-	}
-}
-
-type lifoQueue struct {
-	top  *lifoElement
-	size uint64
-	mu   sync.RWMutex
-}
-
-func (q *lifoQueue) len() uint64 {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	return q.size
-}
-
-func (q *lifoQueue) push(ctx context.Context) (func(), <-chan core.Listener) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	releaseChan := make(chan core.Listener)
-
-	if q.top != nil {
-		q.top = &lifoElement{next: q.top, ctx: ctx, releaseChan: releaseChan}
-		q.top.next.prev = q.top
-	} else {
-		q.top = &lifoElement{ctx: ctx, releaseChan: releaseChan}
-	}
-
-	q.size++
-	return q.evictionFunc(q.top), releaseChan
-}
-
-func (q *lifoQueue) pop() *lifoElement {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	if q.size > 0 {
-		prev := *q.top
-		next := q.top.next
-		if next != nil {
-			next.prev = nil
-		}
-		q.top.next = nil
-		q.top.prev = nil
-		q.top.evicted = true
-
-		q.top = next
-		q.size--
-		return &prev
-	}
-	return nil
-}
-
-func (q *lifoQueue) peek() (func(), *lifoElement) {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-	if q.size > 0 {
-		return q.evictionFunc(q.top), q.top
-	}
-	return nil, nil
-}
-
-// LifoBlockingListener implements a blocking listener for the LifoBlockingListener
-type LifoBlockingListener struct {
-	delegateListener core.Listener
-	limiter          *LifoBlockingLimiter
-}
-
-func (l *LifoBlockingListener) unblock() {
-	l.limiter.mu.Lock()
-	defer l.limiter.mu.Unlock()
-
-	evict, nextEvent := l.limiter.backlog.peek()
-
-	// The queue is empty
-	if nextEvent == nil {
-		return
-	}
-
-	listener, ok := l.limiter.delegate.Acquire(nextEvent.ctx)
-
-	if ok && listener != nil {
-		// We successfully acquired a listener from the
-		// delegate. Now we can evict the element from
-		// the queue
-		evict()
-
-		// If the listener is not accepted due to subtle timings
-		// between setListener being invoked and the element
-		// expiration elapsing we need to be sure to release it.
-		if accepted := nextEvent.setListener(listener); !accepted {
-			listener.OnIgnore()
-		}
-	}
-	// otherwise: still can't acquire the limit.  unblock will be called again next time the limit is released.
-}
-
-// OnDropped is called to indicate the request failed and was dropped due to being rejected by an external limit or
-// hitting a timeout.  Loss based Limit implementations will likely do an aggressive reducing in limit when this
-// happens.
-func (l *LifoBlockingListener) OnDropped() {
-	l.delegateListener.OnDropped()
-	l.unblock()
-}
-
-// OnIgnore is called to indicate the operation failed before any meaningful RTT measurement could be made and
-// should be ignored to not introduce an artificially low RTT.
-func (l *LifoBlockingListener) OnIgnore() {
-	l.delegateListener.OnIgnore()
-	l.unblock()
-}
-
-// OnSuccess is called as a notification that the operation succeeded and internally measured latency should be
-// used as an RTT sample.
-func (l *LifoBlockingListener) OnSuccess() {
-	l.delegateListener.OnSuccess()
-	l.unblock()
-}
 
 // LifoBlockingLimiter implements a Limiter that blocks the caller when the limit has been reached.  This strategy
 // ensures the resource is properly protected but favors availability over latency by not fast failing requests when
@@ -172,69 +12,13 @@ func (l *LifoBlockingListener) OnSuccess() {
 // processed in last in/first out order.
 //
 // Use this limiter only when the concurrency model allows the limiter to be blocked.
+// Deprecated in favor of QueueBlockingLimiter
 type LifoBlockingLimiter struct {
-	delegate            core.Limiter
-	maxBacklogSize      uint64
-	maxBacklogTimeout   time.Duration
-	backlogEvictDoneCtx bool
-
-	backlog *lifoQueue
-	mu      sync.RWMutex
-}
-
-type LifoLimiterConfig struct {
-	MaxBacklogSize      int           `yaml:"maxBacklogSize,omitempty" json:"maxBacklogSize,omitempty"`
-	MaxBacklogTimeout   time.Duration `yaml:"maxBacklogTimeout,omitempty" json:"maxBacklogTimeout,omitempty"`
-	BacklogEvictDoneCtx bool          `yaml:"backlogEvictDoneCtx,omitempty" json:"backlogEvictDoneCtx,omitempty"`
-
-	MetricRegistry core.MetricRegistry
-	Tags           []string `yaml:"tags,omitempty" json:"tags,omitempty"`
-}
-
-func (c *LifoLimiterConfig) ApplyDefaults() {
-
-	if c.MaxBacklogSize <= 0 {
-		c.MaxBacklogSize = 100
-	}
-
-	if c.MaxBacklogTimeout == 0 {
-		c.MaxBacklogTimeout = time.Millisecond * 1000
-	}
-
-	if c.MetricRegistry == nil {
-		c.MetricRegistry = &core.EmptyMetricRegistry{}
-	}
-}
-
-// NewLifoBlockingLimiterFromConfig will create a new LifoBlockingLimiter
-func NewLifoBlockingLimiterFromConfig(
-	delegate core.Limiter,
-	config LifoLimiterConfig,
-) *LifoBlockingLimiter {
-
-	config.ApplyDefaults()
-
-	l := &LifoBlockingLimiter{
-		delegate:            delegate,
-		maxBacklogSize:      uint64(config.MaxBacklogSize),
-		maxBacklogTimeout:   config.MaxBacklogTimeout,
-		backlogEvictDoneCtx: config.BacklogEvictDoneCtx,
-		backlog:             &lifoQueue{},
-	}
-
-	config.MetricRegistry.RegisterGauge(
-		core.MetricLifoQueueLimit, core.NewIntMetricSupplierWrapper(func() int {
-			return config.MaxBacklogSize
-		}), config.Tags...)
-
-	config.MetricRegistry.RegisterGauge(
-		core.MetricLifoQueueSize, core.NewUint64MetricSupplierWrapper(l.backlog.len), config.Tags...)
-
-	return l
+	*QueueBlockingLimiter
 }
 
 // NewLifoBlockingLimiter will create a new LifoBlockingLimiter
-// Deprecated, use NewLifoBlockingLimiterFromConfig instead
+// Deprecated, use NewQueueBlockingLimiterFromConfig instead
 func NewLifoBlockingLimiter(
 	delegate core.Limiter,
 	maxBacklogSize int,
@@ -243,88 +27,23 @@ func NewLifoBlockingLimiter(
 	tags ...string,
 ) *LifoBlockingLimiter {
 
-	return NewLifoBlockingLimiterFromConfig(
-		delegate,
-		LifoLimiterConfig{
-			MaxBacklogSize:    maxBacklogSize,
-			MaxBacklogTimeout: maxBacklogTimeout,
-			MetricRegistry:    registry,
-			Tags:              tags,
-		},
-	)
+	return &LifoBlockingLimiter{
+		NewQueueBlockingLimiterFromConfig(
+			delegate,
+			QueueLimiterConfig{
+				MaxBacklogSize:    maxBacklogSize,
+				MaxBacklogTimeout: maxBacklogTimeout,
+				MetricRegistry:    registry,
+				Tags:              tags,
+			},
+		),
+	}
 }
 
 // NewLifoBlockingLimiterWithDefaults will create a new LifoBlockingLimiter with default values.
+// Deprecated, use NewQueueBlockingLimiterFromConfig
 func NewLifoBlockingLimiterWithDefaults(
 	delegate core.Limiter,
 ) *LifoBlockingLimiter {
-	return NewLifoBlockingLimiterFromConfig(
-		delegate,
-		LifoLimiterConfig{},
-	)
-}
-
-func (l *LifoBlockingLimiter) tryAcquire(ctx context.Context) core.Listener {
-	// Try to acquire a token and return immediately if successful
-	listener, ok := l.delegate.Acquire(ctx)
-	if ok && listener != nil {
-		return listener
-	}
-
-	// Restrict backlog size so the queue doesn't grow unbounded during an outage
-	if l.backlog.len() >= l.maxBacklogSize {
-		return nil
-	}
-
-	// Create a holder for a listener and block until a listener is released by another
-	// operation.  Holders will be unblocked in LIFO order
-	evict, eventReleaseChan := l.backlog.push(ctx)
-
-	// We're using a nil chan so that we
-	// can avoid needing to duplicate the
-	// following select statement to support
-	// a conditional case.
-	var ctxDone <-chan struct{}
-	if l.backlogEvictDoneCtx {
-		ctxDone = ctx.Done()
-	}
-
-	select {
-	case listener = <-eventReleaseChan:
-		// If we have received a listener then that means
-		// that 'unblock' has already evicted this element
-		// from the queue for us.
-		return listener
-	case <-time.After(l.maxBacklogTimeout):
-		// Remove the holder from the backlog.
-		evict()
-		return nil
-	case <-ctxDone:
-		// The context has been cancelled before `maxBacklogTimeout`
-		// could elapse. Since this context no longer needs a listener
-		// we evict it from the backlog to free up space.
-		evict()
-		return nil
-	}
-}
-
-// Acquire a token from the limiter.  Returns an Optional.empty() if the limit has been exceeded.
-// If acquired the caller must call one of the Listener methods when the operation has been completed to release
-// the count.
-//
-// ctx Context for the request. The context is used by advanced strategies such as LookupPartitionStrategy.
-func (l *LifoBlockingLimiter) Acquire(ctx context.Context) (core.Listener, bool) {
-	delegateListener := l.tryAcquire(ctx)
-	if delegateListener == nil {
-		return nil, false
-	}
-	return &LifoBlockingListener{
-		delegateListener: delegateListener,
-		limiter:          l,
-	}, true
-}
-
-func (l *LifoBlockingLimiter) String() string {
-	return fmt.Sprintf("LifoBlockingLimiter{delegate=%v, maxBacklogSize=%d, maxBacklogTimeout=%v}",
-		l.delegate, l.maxBacklogSize, l.maxBacklogTimeout)
+	return NewLifoBlockingLimiter(delegate, 0, 0, nil)
 }

--- a/limiter/lifo_blocking_test.go
+++ b/limiter/lifo_blocking_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -13,128 +12,6 @@ import (
 	"github.com/platinummonkey/go-concurrency-limits/limit"
 	"github.com/platinummonkey/go-concurrency-limits/strategy"
 )
-
-func TestLifoQueue(t *testing.T) {
-	t.Parallel()
-	asrt := assert.New(t)
-	q := lifoQueue{}
-
-	asrt.Equal(uint64(0), q.len())
-	_, ctx := q.peek()
-	asrt.Equal(uint64(0), q.len())
-	asrt.Nil(ctx)
-	asrt.Nil(q.pop())
-
-	ctx1 := context.WithValue(context.Background(), testLifoQueueContextKey(1), 1)
-	q.push(ctx1)
-
-	_, element := q.peek()
-	asrt.Equal(uint64(1), q.len())
-	asrt.NotNil(element.ctx)
-	asrt.Equal(ctx1, element.ctx)
-
-	// add a 2nd
-	ctx2 := context.WithValue(context.Background(), testLifoQueueContextKey(2), 2)
-	q.push(ctx2)
-
-	// make sure it's still LIFO
-	_, element = q.peek()
-	asrt.Equal(uint64(2), q.len())
-	asrt.NotNil(element.ctx)
-	asrt.Equal(ctx2, element.ctx)
-	asrt.Equal(ctx2, q.top.ctx)
-
-	// pop off
-	element = q.pop()
-	asrt.NotNil(element)
-	asrt.Equal(ctx2, element.ctx)
-
-	// check that we only have one again
-	_, element = q.peek()
-	asrt.Equal(uint64(1), q.len())
-	asrt.NotNil(element.ctx)
-	asrt.Equal(ctx1, element.ctx)
-
-	// add a 2nd & 3rd
-	ctx3 := context.WithValue(context.Background(), testLifoQueueContextKey(3), 3)
-	q.push(ctx3)
-	ctx4 := context.WithValue(context.Background(), testLifoQueueContextKey(4), 4)
-	q.push(ctx4)
-
-}
-
-func TestLifoQueue_Evict(t *testing.T) {
-	t.Parallel()
-	asrt := assert.New(t)
-	q := lifoQueue{}
-
-	asrt.Equal(uint64(0), q.len())
-	_, e := q.peek()
-	asrt.Equal(uint64(0), q.len())
-	asrt.Nil(e)
-	asrt.Nil(q.pop())
-
-	var evictFunc []func()
-	for i := 1; i <= 10; i++ {
-		ctx := context.WithValue(context.Background(), testLifoQueueContextKey(1), i)
-		e, _ := q.push(ctx)
-		evictFunc = append(evictFunc, e)
-	}
-
-	// remove last
-	evictFunc[0]()
-	asrt.Equal(uint64(9), q.len())
-
-	// remove first
-	evictFunc[9]()
-	asrt.Equal(uint64(8), q.len())
-
-	// remove middle
-	evictFunc[4]()
-	asrt.Equal(uint64(7), q.len())
-
-	seenElements := make(map[int]struct{}, q.len())
-	var element *lifoElement
-	for {
-		element = q.pop()
-		if element == nil {
-			break
-		}
-		id := element.ctx.Value(testLifoQueueContextKey(1)).(int)
-		_, seen := seenElements[id]
-		asrt.False(seen, "no duplicate element ids allowed")
-		seenElements[id] = struct{}{}
-	}
-	asrt.Equal(uint64(0), q.len())
-	asrt.Equal(7, len(seenElements))
-
-	q = lifoQueue{}
-	ctx := context.WithValue(context.Background(), testLifoQueueContextKey(1), 1)
-	evict, _ := q.push(ctx)
-
-	// Remove very last item leaving queue empty
-	evict()
-	asrt.Equal(uint64(0), q.len())
-}
-
-func TestLifoBlockingListener(t *testing.T) {
-	t.Parallel()
-	delegateLimiter, _ := NewDefaultLimiterWithDefaults(
-		"",
-		strategy.NewSimpleStrategy(20),
-		limit.NoopLimitLogger{},
-		core.EmptyMetricRegistryInstance,
-	)
-	limiter := NewLifoBlockingLimiterWithDefaults(delegateLimiter)
-	delegateListener, _ := delegateLimiter.Acquire(context.Background())
-	listener := LifoBlockingListener{
-		delegateListener: delegateListener,
-		limiter:          limiter,
-	}
-	listener.OnSuccess()
-	listener.OnIgnore()
-	listener.OnDropped()
-}
 
 type acquiredListenerLifo struct {
 	id       int
@@ -155,7 +32,7 @@ func TestLifoBlockingLimiter(t *testing.T) {
 		)
 		limiter := NewLifoBlockingLimiterWithDefaults(delegateLimiter)
 		asrt.NotNil(limiter)
-		asrt.True(strings.Contains(limiter.String(), "LifoBlockingLimiter{delegate=DefaultLimiter{"))
+		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
 	})
 
 	t.Run("NewLifoBlockingLimiter", func(t2 *testing.T) {
@@ -169,7 +46,7 @@ func TestLifoBlockingLimiter(t *testing.T) {
 		)
 		limiter := NewLifoBlockingLimiter(delegateLimiter, -1, 0, nil)
 		asrt.NotNil(limiter)
-		asrt.True(strings.Contains(limiter.String(), "LifoBlockingLimiter{delegate=DefaultLimiter{"))
+		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
 	})
 
 	t.Run("Acquire", func(t2 *testing.T) {
@@ -239,59 +116,5 @@ func TestLifoBlockingLimiter(t *testing.T) {
 				acquired.listener.OnSuccess()
 			}
 		}
-	})
-
-	t.Run("CtxCancelled", func(t2 *testing.T) {
-		t2.Parallel()
-		asrt := assert.New(t2)
-		delegateLimiter, _ := NewDefaultLimiter(
-			limit.NewFixedLimit("test", 10, nil),
-			defaultMinWindowTime,
-			defaultMaxWindowTime,
-			defaultMinRTTThreshold,
-			defaultWindowSize,
-			strategy.NewSimpleStrategy(10),
-			limit.NoopLimitLogger{},
-			core.EmptyMetricRegistryInstance,
-		)
-		limiter := NewLifoBlockingLimiterFromConfig(
-			delegateLimiter,
-			LifoLimiterConfig{
-				BacklogEvictDoneCtx: true,
-				MaxBacklogTimeout:   1 * time.Hour,
-			},
-		)
-		asrt.NotNil(limiter)
-
-		// acquire all tokens first
-		listeners := make([]core.Listener, 0)
-		for i := 0; i < 10; i++ {
-			listener, ok := limiter.Acquire(context.Background())
-			asrt.True(ok)
-			asrt.NotNil(listener)
-			listeners = append(listeners, listener)
-		}
-
-		wg := sync.WaitGroup{}
-		wg.Add(5)
-		for i := 0; i < 5; i++ {
-			go func(j int) {
-				wg.Done()
-				listener, ok := limiter.Acquire(context.Background())
-				asrt.True(ok, "must be true for j %d", j)
-				asrt.NotNil(listener, "must be not be nil for j %d", j)
-			}(i)
-		}
-
-		cancelledCtx, cancel := context.WithCancel(context.Background())
-		time.AfterFunc(50*time.Millisecond, func() {
-			cancel()
-		})
-
-		token, ok := limiter.Acquire(cancelledCtx)
-		asrt.False(ok)
-		asrt.Nil(token)
-
-		asrt.Equal(limiter.backlog.len(), uint64(5))
 	})
 }

--- a/limiter/queue_blocking.go
+++ b/limiter/queue_blocking.go
@@ -10,12 +10,25 @@ import (
 	"github.com/platinummonkey/go-concurrency-limits/core"
 )
 
+// EvictFunc is a type denoting a function used to evict an
+// element from a QueueBlockingLimiter backlog
 type EvictFunc func()
 
+// QueueOrdering is an enum used for configuring the order in
+// which elements in a QueueBlockingLimiter backlog are consumed
 type QueueOrdering string
 
 const (
+	// OrderingFIFO is an enum constant used to represent
+	// a first-in first-out ordering for queue elements.
+	// This means that the oldest elements in a queue are
+	// the first to be consumed
 	OrderingFIFO QueueOrdering = "fifo"
+
+	// OrderingLIFO is an enum constant used to represent
+	// a last-in first-out ordering for queue elements.
+	// This means that the newest elements in a queue are
+	// the first to be consumed
 	OrderingLIFO QueueOrdering = "lifo"
 
 	metricTagOrdering = "ordering"
@@ -180,6 +193,8 @@ type QueueBlockingLimiter struct {
 	mu      sync.RWMutex
 }
 
+// QueueLimiterConfig is a struct used to encapsulate the constructor arguments
+// needed for creating a QueueBlockingLimiter instance
 type QueueLimiterConfig struct {
 	Ordering            QueueOrdering `yaml:"ordering,omitempty" json:"ordering,omitempty"`
 	MaxBacklogSize      int           `yaml:"maxBacklogSize,omitempty" json:"maxBacklogSize,omitempty"`
@@ -190,6 +205,8 @@ type QueueLimiterConfig struct {
 	Tags           []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 }
 
+// ApplyDefaults is used by QueueBlockingLimiter constructors
+// to set defaults for optional limiter configuration arguments
 func (c *QueueLimiterConfig) ApplyDefaults() {
 
 	if c.MaxBacklogSize <= 0 {

--- a/limiter/queue_blocking.go
+++ b/limiter/queue_blocking.go
@@ -1,0 +1,313 @@
+package limiter
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/platinummonkey/go-concurrency-limits/core"
+)
+
+// QueueOrdering defines the pattern for ordering requests on Pool
+type QueueOrdering string
+
+// The available options
+const (
+	OrderingFIFO QueueOrdering = "fifo"
+	OrderingLIFO QueueOrdering = "lifo"
+)
+
+type queueElement struct {
+	ctx         context.Context
+	releaseChan chan<- core.Listener
+	next, prev  *queueElement
+	evicted     bool
+}
+
+func (e *queueElement) setListener(listener core.Listener) bool {
+	select {
+	case e.releaseChan <- listener:
+		close(e.releaseChan)
+		return true
+	default:
+		// timeout has expired
+		return false
+	}
+}
+
+func (q *queue) evictionFunc(e *list.Element) func() {
+	return func() {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+
+		qe := e.Value.(*queueElement)
+		// Prevent multiple invocations from
+		// corrupting the queue state.
+		if qe.evicted {
+			return
+		}
+
+		qe.evicted = true
+		q.list.Remove(e)
+	}
+}
+
+type queue struct {
+	list     *list.List
+	ordering QueueOrdering
+	mu       sync.RWMutex
+}
+
+func (q *queue) len() uint64 {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return uint64(q.list.Len())
+}
+
+func (q *queue) push(ctx context.Context) (func(), <-chan core.Listener) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	releaseChan := make(chan core.Listener)
+
+	e := &queueElement{ctx: ctx, releaseChan: releaseChan}
+	listElement := q.list.PushFront(e)
+
+	return q.evictionFunc(listElement), releaseChan
+}
+
+func (q *queue) pop() *queueElement {
+	evict, ele := q.peek()
+	if evict != nil {
+		evict()
+	}
+
+	return ele
+}
+
+func (q *queue) peek() (func(), *queueElement) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	if q.list.Len() > 0 {
+
+		var element *list.Element
+		switch q.ordering {
+		case OrderingFIFO:
+			element = q.list.Back()
+		case OrderingLIFO:
+			element = q.list.Front()
+		}
+
+		return q.evictionFunc(element), element.Value.(*queueElement)
+	}
+	return nil, nil
+}
+
+// QueueBlockingListener implements a blocking listener for the QueueBlockingListener
+type QueueBlockingListener struct {
+	delegateListener core.Listener
+	limiter          *QueueBlockingLimiter
+}
+
+func (l *QueueBlockingListener) unblock() {
+	l.limiter.mu.Lock()
+	defer l.limiter.mu.Unlock()
+
+	evict, nextEvent := l.limiter.backlog.peek()
+
+	// The queue is empty
+	if nextEvent == nil {
+		return
+	}
+
+	listener, ok := l.limiter.delegate.Acquire(nextEvent.ctx)
+
+	if ok && listener != nil {
+		// We successfully acquired a listener from the
+		// delegate. Now we can evict the element from
+		// the queue
+		evict()
+
+		// If the listener is not accepted due to subtle timings
+		// between setListener being invoked and the element
+		// expiration elapsing we need to be sure to release it.
+		if accepted := nextEvent.setListener(listener); !accepted {
+			listener.OnIgnore()
+		}
+	}
+	// otherwise: still can't acquire the limit.  unblock will be called again next time the limit is released.
+}
+
+// OnDropped is called to indicate the request failed and was dropped due to being rejected by an external limit or
+// hitting a timeout.  Loss based Limit implementations will likely do an aggressive reducing in limit when this
+// happens.
+func (l *QueueBlockingListener) OnDropped() {
+	l.delegateListener.OnDropped()
+	l.unblock()
+}
+
+// OnIgnore is called to indicate the operation failed before any meaningful RTT measurement could be made and
+// should be ignored to not introduce an artificially low RTT.
+func (l *QueueBlockingListener) OnIgnore() {
+	l.delegateListener.OnIgnore()
+	l.unblock()
+}
+
+// OnSuccess is called as a notification that the operation succeeded and internally measured latency should be
+// used as an RTT sample.
+func (l *QueueBlockingListener) OnSuccess() {
+	l.delegateListener.OnSuccess()
+	l.unblock()
+}
+
+// QueueBlockingLimiter implements a Limiter that blocks the caller when the limit has been reached.  This strategy
+// ensures the resource is properly protected but favors availability over latency by not fast failing requests when
+// the limit has been reached.  To help keep success latencies low and minimize timeouts any blocked requests are
+// processed in last in/first out order.
+//
+// Use this limiter only when the concurrency model allows the limiter to be blocked.
+type QueueBlockingLimiter struct {
+	delegate            core.Limiter
+	maxBacklogSize      uint64
+	maxBacklogTimeout   time.Duration
+	backlogEvictDoneCtx bool
+	ordering            QueueOrdering
+
+	backlog *queue
+	mu      sync.RWMutex
+}
+
+type QueueLimiterConfig struct {
+	Ordering            QueueOrdering `yaml:"ordering,omitempty" json:"ordering,omitempty"`
+	MaxBacklogSize      int           `yaml:"maxBacklogSize,omitempty" json:"maxBacklogSize,omitempty"`
+	MaxBacklogTimeout   time.Duration `yaml:"maxBacklogTimeout,omitempty" json:"maxBacklogTimeout,omitempty"`
+	BacklogEvictDoneCtx bool          `yaml:"backlogEvictDoneCtx,omitempty" json:"backlogEvictDoneCtx,omitempty"`
+
+	MetricRegistry core.MetricRegistry
+	Tags           []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+}
+
+func (c *QueueLimiterConfig) ApplyDefaults() {
+
+	if c.MaxBacklogSize <= 0 {
+		c.MaxBacklogSize = 100
+	}
+
+	if c.MaxBacklogTimeout == 0 {
+		c.MaxBacklogTimeout = time.Millisecond * 1000
+	}
+
+	if c.MetricRegistry == nil {
+		c.MetricRegistry = &core.EmptyMetricRegistry{}
+	}
+
+	if c.Ordering == "" {
+		c.Ordering = OrderingLIFO
+	}
+}
+
+// NewQueueBlockingLimiterFromConfig will create a new QueueBlockingLimiter
+func NewQueueBlockingLimiterFromConfig(
+	delegate core.Limiter,
+	config QueueLimiterConfig,
+) *QueueBlockingLimiter {
+
+	config.ApplyDefaults()
+
+	l := &QueueBlockingLimiter{
+		delegate:            delegate,
+		maxBacklogSize:      uint64(config.MaxBacklogSize),
+		maxBacklogTimeout:   config.MaxBacklogTimeout,
+		backlogEvictDoneCtx: config.BacklogEvictDoneCtx,
+		backlog: &queue{
+			list:     list.New(),
+			ordering: OrderingFIFO,
+		},
+	}
+
+	config.MetricRegistry.RegisterGauge(
+		core.MetricQueueLimit, core.NewIntMetricSupplierWrapper(func() int {
+			return config.MaxBacklogSize
+		}), config.Tags...)
+
+	config.MetricRegistry.RegisterGauge(
+		core.MetricQueueSize, core.NewUint64MetricSupplierWrapper(l.backlog.len), config.Tags...)
+
+	return l
+}
+
+// NewQueueBlockingLimiterWithDefaults will create a new QueueBlockingLimiter with default values.
+func NewQueueBlockingLimiterWithDefaults(
+	delegate core.Limiter,
+) *QueueBlockingLimiter {
+	return NewQueueBlockingLimiterFromConfig(
+		delegate,
+		QueueLimiterConfig{},
+	)
+}
+
+func (l *QueueBlockingLimiter) tryAcquire(ctx context.Context) core.Listener {
+	// Try to acquire a token and return immediately if successful
+	listener, ok := l.delegate.Acquire(ctx)
+	if ok && listener != nil {
+		return listener
+	}
+
+	// Restrict backlog size so the queue doesn't grow unbounded during an outage
+	if l.backlog.len() >= l.maxBacklogSize {
+		return nil
+	}
+
+	// Create a holder for a listener and block until a listener is released by another
+	// operation.  Holders will be unblocked in LIFO order
+	evict, eventReleaseChan := l.backlog.push(ctx)
+
+	// We're using a nil chan so that we
+	// can avoid needing to duplicate the
+	// following select statement to support
+	// a conditional case.
+	var ctxDone <-chan struct{}
+	if l.backlogEvictDoneCtx {
+		ctxDone = ctx.Done()
+	}
+
+	select {
+	case listener = <-eventReleaseChan:
+		// If we have received a listener then that means
+		// that 'unblock' has already evicted this element
+		// from the queue for us.
+		return listener
+	case <-time.After(l.maxBacklogTimeout):
+		// Remove the holder from the backlog.
+		evict()
+		return nil
+	case <-ctxDone:
+		// The context has been cancelled before `maxBacklogTimeout`
+		// could elapse. Since this context no longer needs a listener
+		// we evict it from the backlog to free up space.
+		evict()
+		return nil
+	}
+}
+
+// Acquire a token from the limiter.  Returns an Optional.empty() if the limit has been exceeded.
+// If acquired the caller must call one of the Listener methods when the operation has been completed to release
+// the count.
+//
+// ctx Context for the request. The context is used by advanced strategies such as LookupPartitionStrategy.
+func (l *QueueBlockingLimiter) Acquire(ctx context.Context) (core.Listener, bool) {
+	delegateListener := l.tryAcquire(ctx)
+	if delegateListener == nil {
+		return nil, false
+	}
+	return &QueueBlockingListener{
+		delegateListener: delegateListener,
+		limiter:          l,
+	}, true
+}
+
+func (l *QueueBlockingLimiter) String() string {
+	return fmt.Sprintf("QueueBlockingLimiter{delegate=%v, maxBacklogSize=%d, maxBacklogTimeout=%v, ordering=%v}",
+		l.delegate, l.maxBacklogSize, l.maxBacklogTimeout, l.ordering)
+}

--- a/limiter/queue_blocking.go
+++ b/limiter/queue_blocking.go
@@ -17,6 +17,8 @@ type QueueOrdering string
 const (
 	OrderingFIFO QueueOrdering = "fifo"
 	OrderingLIFO QueueOrdering = "lifo"
+
+	metricTagOrdering = "ordering"
 )
 
 type queueElement struct {
@@ -205,6 +207,8 @@ func (c *QueueLimiterConfig) ApplyDefaults() {
 	if c.Ordering == "" {
 		c.Ordering = OrderingLIFO
 	}
+
+	c.Tags = append(c.Tags, metricTagOrdering, string(c.Ordering))
 }
 
 // NewQueueBlockingLimiterFromConfig will create a new QueueBlockingLimiter

--- a/limiter/queue_blocking_test.go
+++ b/limiter/queue_blocking_test.go
@@ -1,6 +1,7 @@
 package limiter
 
 import (
+	"container/list"
 	"context"
 	"strings"
 	"sync"
@@ -14,10 +15,193 @@ import (
 	"github.com/platinummonkey/go-concurrency-limits/strategy"
 )
 
-func TestLifoQueue(t *testing.T) {
+type testFifoQueueContextKey int
+
+func TestQueue_Fifo(t *testing.T) {
 	t.Parallel()
 	asrt := assert.New(t)
-	q := lifoQueue{}
+	q := queue{
+		list:     list.New(),
+		ordering: OrderingFIFO,
+	}
+
+	asrt.Equal(uint64(0), q.len())
+	_, el := q.peek()
+	asrt.Nil(el)
+	asrt.Nil(q.pop())
+
+	ctx1 := context.WithValue(context.Background(), testFifoQueueContextKey(1), 1)
+	q.push(ctx1)
+
+	_, el = q.peek()
+	asrt.Equal(uint64(1), q.len())
+	asrt.NotNil(el)
+	asrt.Equal(ctx1, el.ctx)
+
+	// add a 2nd
+	ctx2 := context.WithValue(context.Background(), testFifoQueueContextKey(2), 2)
+	q.push(ctx2)
+
+	// make sure it's still FIFO
+	_, el = q.peek()
+	asrt.Equal(uint64(2), q.len())
+	asrt.NotNil(el)
+	asrt.Equal(ctx1, el.ctx)
+
+	// pop off
+	el = q.pop()
+	asrt.NotNil(el)
+	asrt.Equal(ctx1, el.ctx)
+
+	// check that we only have one again
+	_, el = q.peek()
+	asrt.Equal(uint64(1), q.len())
+	asrt.NotNil(el)
+	asrt.Equal(ctx2, el.ctx)
+
+	// add a 2nd & 3rd
+	ctx3 := context.WithValue(context.Background(), testFifoQueueContextKey(3), 3)
+	evict3, _ := q.push(ctx3)
+	ctx4 := context.WithValue(context.Background(), testFifoQueueContextKey(4), 4)
+	q.push(ctx4)
+
+	// remove the middle
+	evict3()
+	_, el = q.peek()
+	asrt.Equal(uint64(2), q.len())
+	asrt.NotNil(el)
+	asrt.Equal(ctx2, el.ctx)
+	asrt.Equal(ctx4, q.list.Front().Value.(*queueElement).ctx)
+}
+
+func TestBlockingListener_Fifo(t *testing.T) {
+	t.Parallel()
+	delegateLimiter, _ := NewDefaultLimiterWithDefaults(
+		"",
+		strategy.NewSimpleStrategy(20),
+		limit.NoopLimitLogger{},
+		core.EmptyMetricRegistryInstance,
+	)
+	limiter := NewQueueBlockingLimiterFromConfig(delegateLimiter, QueueLimiterConfig{
+		Ordering: OrderingFIFO,
+	})
+	delegateListener, _ := delegateLimiter.Acquire(context.Background())
+	listener := QueueBlockingListener{
+		delegateListener: delegateListener,
+		limiter:          limiter,
+	}
+	listener.OnSuccess()
+	listener.OnIgnore()
+	listener.OnDropped()
+}
+
+type acquiredListenerFifo struct {
+	id       int
+	listener core.Listener
+}
+
+func TestBlockingLimiter_Fifo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NewFifoBlockingLimiter", func(t2 *testing.T) {
+		t2.Parallel()
+		asrt := assert.New(t2)
+		delegateLimiter, _ := NewDefaultLimiterWithDefaults(
+			"",
+			strategy.NewSimpleStrategy(20),
+			limit.NoopLimitLogger{},
+			core.EmptyMetricRegistryInstance,
+		)
+		limiter := NewQueueBlockingLimiterFromConfig(delegateLimiter, QueueLimiterConfig{
+			MaxBacklogSize:    -1,
+			MaxBacklogTimeout: 0,
+			Ordering:          OrderingFIFO,
+		})
+		asrt.NotNil(limiter)
+		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
+	})
+
+	t.Run("Acquire", func(t2 *testing.T) {
+		t2.Parallel()
+		asrt := assert.New(t2)
+		delegateLimiter, _ := NewDefaultLimiter(
+			limit.NewFixedLimit("test", 10, nil),
+			defaultMinWindowTime,
+			defaultMaxWindowTime,
+			defaultMinRTTThreshold,
+			defaultWindowSize,
+			strategy.NewSimpleStrategy(10),
+			limit.NoopLimitLogger{},
+			core.EmptyMetricRegistryInstance,
+		)
+		limiter := NewQueueBlockingLimiterFromConfig(delegateLimiter, QueueLimiterConfig{
+			Ordering: OrderingFIFO,
+		})
+		asrt.NotNil(limiter)
+
+		// acquire all tokens first
+		listeners := make([]core.Listener, 0)
+		for i := 0; i < 10; i++ {
+			listener, ok := limiter.Acquire(context.Background())
+			asrt.True(ok)
+			asrt.NotNil(listener)
+			listeners = append(listeners, listener)
+		}
+
+		// queue up 10 more waiting
+		waitingListeners := make([]acquiredListenerFifo, 0)
+		mu := sync.Mutex{}
+		startupReady := make(chan bool, 1)
+		wg := sync.WaitGroup{}
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
+			if i > 0 {
+				select {
+				case <-startupReady:
+					// proceed
+				}
+			}
+			go func(j int) {
+				startupReady <- true
+				listener, ok := limiter.Acquire(context.Background())
+				asrt.True(ok)
+				asrt.NotNil(listener)
+				mu.Lock()
+				waitingListeners = append(waitingListeners, acquiredListenerFifo{id: j, listener: listener})
+				mu.Unlock()
+				wg.Done()
+			}(i)
+		}
+
+		// release all other listeners, so we can continue
+		for _, listener := range listeners {
+			listener.OnSuccess()
+		}
+
+		// wait for others
+		wg.Wait()
+
+		// check all eventually required. Note: due to scheduling, it's not entirely LIFO as scheduling will allow
+		// some non-determinism
+		asrt.Len(waitingListeners, 10)
+		// release all
+		for _, acquired := range waitingListeners {
+			if acquired.listener != nil {
+				acquired.listener.OnSuccess()
+			}
+		}
+	})
+}
+
+type testLifoQueueContextKey int
+
+func TestQueue_Lifo(t *testing.T) {
+	t.Parallel()
+	asrt := assert.New(t)
+	q := queue{
+		list:     list.New(),
+		ordering: OrderingLIFO,
+	}
 
 	asrt.Equal(uint64(0), q.len())
 	_, ctx := q.peek()
@@ -42,7 +226,7 @@ func TestLifoQueue(t *testing.T) {
 	asrt.Equal(uint64(2), q.len())
 	asrt.NotNil(element.ctx)
 	asrt.Equal(ctx2, element.ctx)
-	asrt.Equal(ctx2, q.top.ctx)
+	asrt.Equal(ctx2, q.list.Front().Value.(*queueElement).ctx)
 
 	// pop off
 	element = q.pop()
@@ -63,10 +247,13 @@ func TestLifoQueue(t *testing.T) {
 
 }
 
-func TestLifoQueue_Evict(t *testing.T) {
+func TestQueue_Lifo_Evict(t *testing.T) {
 	t.Parallel()
 	asrt := assert.New(t)
-	q := lifoQueue{}
+	q := queue{
+		list:     list.New(),
+		ordering: OrderingLIFO,
+	}
 
 	asrt.Equal(uint64(0), q.len())
 	_, e := q.peek()
@@ -94,7 +281,7 @@ func TestLifoQueue_Evict(t *testing.T) {
 	asrt.Equal(uint64(7), q.len())
 
 	seenElements := make(map[int]struct{}, q.len())
-	var element *lifoElement
+	var element *queueElement
 	for {
 		element = q.pop()
 		if element == nil {
@@ -108,7 +295,10 @@ func TestLifoQueue_Evict(t *testing.T) {
 	asrt.Equal(uint64(0), q.len())
 	asrt.Equal(7, len(seenElements))
 
-	q = lifoQueue{}
+	q = queue{
+		list:     list.New(),
+		ordering: OrderingLIFO,
+	}
 	ctx := context.WithValue(context.Background(), testLifoQueueContextKey(1), 1)
 	evict, _ := q.push(ctx)
 
@@ -117,7 +307,7 @@ func TestLifoQueue_Evict(t *testing.T) {
 	asrt.Equal(uint64(0), q.len())
 }
 
-func TestLifoBlockingListener(t *testing.T) {
+func TestQueueBlockingListener_Lifo(t *testing.T) {
 	t.Parallel()
 	delegateLimiter, _ := NewDefaultLimiterWithDefaults(
 		"",
@@ -136,27 +326,8 @@ func TestLifoBlockingListener(t *testing.T) {
 	listener.OnDropped()
 }
 
-type acquiredListenerLifo struct {
-	id       int
-	listener core.Listener
-}
-
-func TestLifoBlockingLimiter(t *testing.T) {
+func TestQueueBlockingLimiter_Lifo(t *testing.T) {
 	t.Parallel()
-
-	t.Run("NewLifoBlockingLimiterWithDefaults", func(t2 *testing.T) {
-		t2.Parallel()
-		asrt := assert.New(t2)
-		delegateLimiter, _ := NewDefaultLimiterWithDefaults(
-			"",
-			strategy.NewSimpleStrategy(20),
-			limit.NoopLimitLogger{},
-			core.EmptyMetricRegistryInstance,
-		)
-		limiter := NewLifoBlockingLimiterWithDefaults(delegateLimiter)
-		asrt.NotNil(limiter)
-		asrt.True(strings.Contains(limiter.String(), "LifoBlockingLimiter{delegate=DefaultLimiter{"))
-	})
 
 	t.Run("NewLifoBlockingLimiter", func(t2 *testing.T) {
 		t2.Parallel()
@@ -167,9 +338,13 @@ func TestLifoBlockingLimiter(t *testing.T) {
 			limit.NoopLimitLogger{},
 			core.EmptyMetricRegistryInstance,
 		)
-		limiter := NewLifoBlockingLimiter(delegateLimiter, -1, 0, nil)
+		limiter := NewQueueBlockingLimiterFromConfig(delegateLimiter, QueueLimiterConfig{
+			MaxBacklogSize:    -1,
+			MaxBacklogTimeout: 0,
+			Ordering:          OrderingLIFO,
+		})
 		asrt.NotNil(limiter)
-		asrt.True(strings.Contains(limiter.String(), "LifoBlockingLimiter{delegate=DefaultLimiter{"))
+		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
 	})
 
 	t.Run("Acquire", func(t2 *testing.T) {
@@ -185,7 +360,9 @@ func TestLifoBlockingLimiter(t *testing.T) {
 			limit.NoopLimitLogger{},
 			core.EmptyMetricRegistryInstance,
 		)
-		limiter := NewLifoBlockingLimiterWithDefaults(delegateLimiter)
+		limiter := NewQueueBlockingLimiterFromConfig(delegateLimiter, QueueLimiterConfig{
+			Ordering: OrderingLIFO,
+		})
 		asrt.NotNil(limiter)
 
 		// acquire all tokens first

--- a/limiter/queue_blocking_test.go
+++ b/limiter/queue_blocking_test.go
@@ -315,9 +315,9 @@ func TestQueueBlockingListener_Lifo(t *testing.T) {
 		limit.NoopLimitLogger{},
 		core.EmptyMetricRegistryInstance,
 	)
-	limiter := NewLifoBlockingLimiterWithDefaults(delegateLimiter)
+	limiter := NewQueueBlockingLimiterWithDefaults(delegateLimiter)
 	delegateListener, _ := delegateLimiter.Acquire(context.Background())
-	listener := LifoBlockingListener{
+	listener := QueueBlockingListener{
 		delegateListener: delegateListener,
 		limiter:          limiter,
 	}
@@ -329,7 +329,7 @@ func TestQueueBlockingListener_Lifo(t *testing.T) {
 func TestQueueBlockingLimiter_Lifo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("NewLifoBlockingLimiter", func(t2 *testing.T) {
+	t.Run("NewQueueBlockingLimiter", func(t2 *testing.T) {
 		t2.Parallel()
 		asrt := assert.New(t2)
 		delegateLimiter, _ := NewDefaultLimiterWithDefaults(
@@ -431,9 +431,9 @@ func TestQueueBlockingLimiter_Lifo(t *testing.T) {
 			limit.NoopLimitLogger{},
 			core.EmptyMetricRegistryInstance,
 		)
-		limiter := NewLifoBlockingLimiterFromConfig(
+		limiter := NewQueueBlockingLimiterFromConfig(
 			delegateLimiter,
-			LifoLimiterConfig{
+			QueueLimiterConfig{
 				BacklogEvictDoneCtx: true,
 				MaxBacklogTimeout:   1 * time.Hour,
 			},

--- a/patterns/pool/fixed_pool.go
+++ b/patterns/pool/fixed_pool.go
@@ -79,14 +79,24 @@ func NewFixedPool(
 	switch ordering {
 	case OrderingFIFO:
 		fp = FixedPool{
-			limit:    fixedLimit,
-			limiter:  limiter.NewFifoBlockingLimiter(defaultLimiter, maxBacklog, timeout),
+			limit: fixedLimit,
+			limiter: limiter.NewQueueBlockingLimiterFromConfig(defaultLimiter, limiter.QueueLimiterConfig{
+				Ordering:          limiter.OrderingFIFO,
+				MaxBacklogSize:    maxBacklog,
+				MaxBacklogTimeout: timeout,
+				MetricRegistry:    metricRegistry,
+			}),
 			ordering: ordering,
 		}
 	case OrderingLIFO:
 		fp = FixedPool{
-			limit:    fixedLimit,
-			limiter:  limiter.NewLifoBlockingLimiter(defaultLimiter, maxBacklog, timeout, metricRegistry),
+			limit: fixedLimit,
+			limiter: limiter.NewQueueBlockingLimiterFromConfig(defaultLimiter, limiter.QueueLimiterConfig{
+				Ordering:          limiter.OrderingLIFO,
+				MaxBacklogSize:    maxBacklog,
+				MaxBacklogTimeout: timeout,
+				MetricRegistry:    metricRegistry,
+			}),
 			ordering: ordering,
 		}
 	default:

--- a/patterns/pool/fixed_pool.go
+++ b/patterns/pool/fixed_pool.go
@@ -114,6 +114,7 @@ func (p *FixedPool) Limit() int {
 	return p.limit
 }
 
+// Ordering the ordering strategy configured for this pool.
 func (p *FixedPool) Ordering() Ordering {
 	return p.ordering
 }

--- a/patterns/pool/generic_pool.go
+++ b/patterns/pool/generic_pool.go
@@ -54,11 +54,21 @@ func NewPool(
 	switch ordering {
 	case OrderingFIFO:
 		p = Pool{
-			limiter: limiter.NewFifoBlockingLimiter(delegateLimiter, maxBacklog, timeout),
+			limiter: limiter.NewQueueBlockingLimiterFromConfig(delegateLimiter, limiter.QueueLimiterConfig{
+				Ordering:          limiter.OrderingFIFO,
+				MaxBacklogSize:    maxBacklog,
+				MaxBacklogTimeout: timeout,
+				MetricRegistry:    metricRegistry,
+			}),
 		}
 	case OrderingLIFO:
 		p = Pool{
-			limiter: limiter.NewLifoBlockingLimiter(delegateLimiter, maxBacklog, timeout, metricRegistry),
+			limiter: limiter.NewQueueBlockingLimiterFromConfig(delegateLimiter, limiter.QueueLimiterConfig{
+				Ordering:          limiter.OrderingLIFO,
+				MaxBacklogSize:    maxBacklog,
+				MaxBacklogTimeout: timeout,
+				MetricRegistry:    metricRegistry,
+			}),
 		}
 	default:
 		p = Pool{


### PR DESCRIPTION
This PR creates a new limiter type named `QueueBlockingLimiter`. This limiter is meant to replace `LifoBlockingLimiter` as well as `FifoBlockingLimiter`. This new queue takes all the improvements made to the lifo queue implementation as well as refactors the queue implementation to use a `List` internally, just like the fifo queue impl. The queue direction is controlled via configuration enum passed in at instantiation time. The existing queue tests have been ported over. If this proposal is acceptable then one thing I would like a little guidance on is what course of action to take for the existing queues and pool implementations? Would it make sense to fully deprecate the old methods and wait a few release cycles or remove them completely and release a breaking change.


EDIT: I used a combination of type aliasing and embedding to deprecate the older queue limiter types