### PR TITLE
Fixes for blocking limiter and perf improvements

### DIFF
--- a/core/metric_registry.go
+++ b/core/metric_registry.go
@@ -103,6 +103,17 @@ type CommonMetricSampler struct {
 	InFlightListener    MetricSampleListener
 }
 
+// NewCommonMetricSamplerOrNil will only create a new CommonMetricSampler if a valid registry is supplied
+func NewCommonMetricSamplerOrNil(registry MetricRegistry, limit Limit, name string, tags ...string) *CommonMetricSampler {
+	if registry == nil {
+		return nil
+	}
+	if _, ok := registry.(*EmptyMetricRegistry); ok {
+		return nil
+	}
+	return NewCommonMetricSampler(registry, limit, name, tags...)
+}
+
 // NewCommonMetricSampler will create a new CommonMetricSampler that will auto-instrument metrics
 func NewCommonMetricSampler(registry MetricRegistry, limit Limit, name string, tags ...string) *CommonMetricSampler {
 	if registry == nil {
@@ -124,6 +135,11 @@ func NewCommonMetricSampler(registry MetricRegistry, limit Limit, name string, t
 
 // Sample will sample the current sample for metric reporting.
 func (s *CommonMetricSampler) Sample(rtt int64, inFlight int, didDrop bool) {
+	// from noop metrics registry
+	if s == nil {
+		return
+	}
+
 	if didDrop {
 		s.DropCounterListener.AddSample(1.0)
 	}

--- a/limit/aimd.go
+++ b/limit/aimd.go
@@ -2,9 +2,10 @@ package limit
 
 import (
 	"fmt"
-	"github.com/platinummonkey/go-concurrency-limits/core"
 	"math"
 	"sync"
+
+	"github.com/platinummonkey/go-concurrency-limits/core"
 )
 
 // AIMDLimit implements a Loss based dynamic Limit that does an additive increment as long as there are no errors and a
@@ -55,7 +56,7 @@ func NewAIMDLimit(
 		listeners:    make([]core.LimitChangeListener, 0),
 		registry:     registry,
 	}
-	l.commonSampler = core.NewCommonMetricSampler(registry, l, name, tags...)
+	l.commonSampler = core.NewCommonMetricSamplerOrNil(registry, l, name, tags...)
 	return l
 }
 

--- a/limit/fixed.go
+++ b/limit/fixed.go
@@ -2,6 +2,7 @@ package limit
 
 import (
 	"fmt"
+
 	"github.com/platinummonkey/go-concurrency-limits/core"
 )
 
@@ -26,7 +27,7 @@ func NewFixedLimit(name string, limit int, registry core.MetricRegistry, tags ..
 		limit:    limit,
 		registry: registry,
 	}
-	l.commonSampler = core.NewCommonMetricSampler(registry, l, name, tags...)
+	l.commonSampler = core.NewCommonMetricSamplerOrNil(registry, l, name, tags...)
 	return l
 }
 

--- a/limit/gradient.go
+++ b/limit/gradient.go
@@ -106,7 +106,7 @@ func NewGradientLimitWithRegistry(
 		queueSizeSampleListener:    registry.RegisterDistribution(core.PrefixMetricWithName(core.MetricWindowQueueSize, name), tags...),
 	}
 
-	l.commonSampler = core.NewCommonMetricSampler(registry, l, name, tags...)
+	l.commonSampler = core.NewCommonMetricSamplerOrNil(registry, l, name, tags...)
 	return l
 }
 

--- a/limit/gradient2.go
+++ b/limit/gradient2.go
@@ -18,28 +18,29 @@ import (
 // characteristics.
 //
 // The core algorithm re-calculates the limit every sampling window (ex. 1 second) using the formula
-//     // Calculate the gradient limiting to the range [0.5, 1.0] to filter outliers
-//     gradient = max(0.5, min(1.0, longtermRtt / currentRtt));
 //
-//     // Calculate the new limit by applying the gradient and allowing for some queuing
-//     newLimit = gradient * currentLimit + queueSize;
+//	// Calculate the gradient limiting to the range [0.5, 1.0] to filter outliers
+//	gradient = max(0.5, min(1.0, longtermRtt / currentRtt));
 //
-//     // Update the limit using a smoothing factor (default 0.2)
-//     newLimit = currentLimit * (1-smoothing) + newLimit * smoothing
+//	// Calculate the new limit by applying the gradient and allowing for some queuing
+//	newLimit = gradient * currentLimit + queueSize;
 //
-// The limit can be in one of three main states
+//	// Update the limit using a smoothing factor (default 0.2)
+//	newLimit = currentLimit * (1-smoothing) + newLimit * smoothing
 //
-// 1. Steady state
-//    In this state the average RTT is very stable and the current measurement whipsaws around this value, sometimes
-//    reducing the limit, sometimes increasing it.
-// 2. Transition from steady state to load
-//    In this state either the RPS to latency has spiked. The gradient is < 1.0 due to a growing request queue that
-//    cannot be handled by the system. Excessive requests and rejected due to the low limit. The baseline RTT grows using
-//    exponential decay but lags the current measurement, which keeps the gradient < 1.0 and limit low.
-// 3. Transition from load to steady state
-//    In this state the system goes back to steady state after a prolonged period of excessive load.  Requests aren't
-//    rejected and the sample RTT remains low. During this state the long term RTT may take some time to go back to
-//    normal and could potentially be several multiples higher than the current RTT.
+// # The limit can be in one of three main states
+//
+//  1. Steady state
+//     In this state the average RTT is very stable and the current measurement whipsaws around this value, sometimes
+//     reducing the limit, sometimes increasing it.
+//  2. Transition from steady state to load
+//     In this state either the RPS to latency has spiked. The gradient is < 1.0 due to a growing request queue that
+//     cannot be handled by the system. Excessive requests and rejected due to the low limit. The baseline RTT grows using
+//     exponential decay but lags the current measurement, which keeps the gradient < 1.0 and limit low.
+//  3. Transition from load to steady state
+//     In this state the system goes back to steady state after a prolonged period of excessive load.  Requests aren't
+//     rejected and the sample RTT remains low. During this state the long term RTT may take some time to go back to
+//     normal and could potentially be several multiples higher than the current RTT.
 type Gradient2Limit struct {
 	// Estimated concurrency limit based on our algorithm
 	estimatedLimit float64
@@ -91,11 +92,17 @@ func NewDefaultGradient2Limit(
 // @param initialLimit: Initial limit used by the limiter.
 // @param maxConcurrency: Maximum allowable concurrency.  Any estimated concurrency will be capped.
 // @param minLimit: Minimum concurrency limit allowed.  The minimum helps prevent the algorithm from adjust the limit
-//                  too far down.  Note that this limit is not desirable when use as backpressure for batch apps.
+//
+//	too far down.  Note that this limit is not desirable when use as backpressure for batch apps.
+//
 // @param queueSizeFunc: Function to dynamically determine the amount the estimated limit can grow while
-//                       latencies remain low as a function of the current limit.
+//
+//	latencies remain low as a function of the current limit.
+//
 // @param smoothing: Smoothing factor to limit how aggressively the estimated limit can shrink when queuing has been
-//                   detected.  Value of 0.0 to 1.0 where 1.0 means the limit is completely replicated by the new estimate.
+//
+//	detected.  Value of 0.0 to 1.0 where 1.0 means the limit is completely replicated by the new estimate.
+//
 // @param longWindow: long time window for the exponential avg recordings.
 // @param registry: metric registry to publish metrics
 func NewGradient2Limit(
@@ -156,7 +163,7 @@ func NewGradient2Limit(
 		registry:                registry,
 	}
 
-	l.commonSampler = core.NewCommonMetricSampler(registry, l, name, tags...)
+	l.commonSampler = core.NewCommonMetricSamplerOrNil(registry, l, name, tags...)
 
 	return l, nil
 }

--- a/limit/traced.go
+++ b/limit/traced.go
@@ -79,6 +79,6 @@ func (l *TracedLimit) OnSample(startTime int64, rtt int64, inFlight int, didDrop
 	l.limit.OnSample(startTime, rtt, inFlight, didDrop)
 }
 
-func (l TracedLimit) String() string {
+func (l *TracedLimit) String() string {
 	return fmt.Sprintf("TracedLimit{limit=%v, logger=%v}", l.limit, l.logger)
 }

--- a/limit/vegas.go
+++ b/limit/vegas.go
@@ -15,7 +15,8 @@ import (
 // small < alpha and decreases by alpha if the queue_use is large > beta.
 //
 // Queue size is calculated using the formula,
-//   queue_use = limit − BWE×RTTnoLoad = limit × (1 − RTTnoLoad/RTTactual)
+//
+//	queue_use = limit − BWE×RTTnoLoad = limit × (1 − RTTnoLoad/RTTactual)
 //
 // For traditional TCP Vegas alpha is typically 2-3 and beta is typically 4-6.  To allow for better growth and stability
 // at higher limits we set alpha=Max(3, 10% of the current limit) and beta=Max(6, 20% of the current limit).
@@ -184,7 +185,7 @@ func NewVegasLimitWithRegistry(
 		logger:            logger,
 	}
 
-	l.commonSampler = core.NewCommonMetricSampler(registry, l, name, tags...)
+	l.commonSampler = core.NewCommonMetricSamplerOrNil(registry, l, name, tags...)
 	return l
 }
 

--- a/limit/vegas.go
+++ b/limit/vegas.go
@@ -15,8 +15,7 @@ import (
 // small < alpha and decreases by alpha if the queue_use is large > beta.
 //
 // Queue size is calculated using the formula,
-//
-//	queue_use = limit − BWE×RTTnoLoad = limit × (1 − RTTnoLoad/RTTactual)
+//   queue_use = limit − BWE×RTTnoLoad = limit × (1 − RTTnoLoad/RTTactual)
 //
 // For traditional TCP Vegas alpha is typically 2-3 and beta is typically 4-6.  To allow for better growth and stability
 // at higher limits we set alpha=Max(3, 10% of the current limit) and beta=Max(6, 20% of the current limit).

--- a/limit/windowed.go
+++ b/limit/windowed.go
@@ -96,7 +96,7 @@ func NewWindowedLimit(
 		listeners:       make([]core.LimitChangeListener, 0),
 		registry:        registry,
 	}
-	l.commonSampler = core.NewCommonMetricSampler(registry, l, name, tags...)
+	l.commonSampler = core.NewCommonMetricSamplerOrNil(registry, l, name, tags...)
 	return l, nil
 
 }

--- a/limiter/delegate_listener.go
+++ b/limiter/delegate_listener.go
@@ -21,28 +21,27 @@ func NewDelegateListener(delegateListener core.Listener) *DelegateListener {
 	}
 }
 
-func (l *DelegateListener) unblock() {
-	l.c.Broadcast()
-}
-
 // OnDropped is called to indicate the request failed and was dropped due to being rejected by an external limit or
 // hitting a timeout.  Loss based Limit implementations will likely do an aggressive reducing in limit when this
 // happens.
 func (l *DelegateListener) OnDropped() {
 	l.delegateListener.OnDropped()
-	l.unblock()
+	// unblock
+	l.c.Broadcast()
 }
 
 // OnIgnore is called to indicate the operation failed before any meaningful RTT measurement could be made and
 // should be ignored to not introduce an artificially low RTT.
 func (l *DelegateListener) OnIgnore() {
 	l.delegateListener.OnIgnore()
-	l.unblock()
+	// unblock
+	l.c.Broadcast()
 }
 
 // OnSuccess is called as a notification that the operation succeeded and internally measured latency should be
 // used as an RTT sample.
 func (l *DelegateListener) OnSuccess() {
 	l.delegateListener.OnSuccess()
-	l.unblock()
+	// unblock
+	l.c.Broadcast()
 }


### PR DESCRIPTION
I was writing a benchmark for the blocking limiter when I realized that it was susceptible to deadlocks. 

This PR introduces the following changes
* Mild refactor of `BlockingLimiter` and `DeadlineLimiter`
  * This reduces the number of goroutines needed to block down to 1
  * The blocking code now creates a timer and explicitly releases it when no longer needed so that it can be reclaimed without needing to elapse
  * Added a benchmark for blocking limiter
 * Reduce overhead of common metrics sampler in scenarios where the metrics registry is not supplied or noop. 
 * Refactor `SettableLimiter` to reduce the number of mutex checks
 