### PR TITLE
Fix gradient limit calculation

### DIFF
--- a/limit/gradient.go
+++ b/limit/gradient.go
@@ -184,7 +184,7 @@ func (l *GradientLimit) OnSample(startTime int64, rtt int64, inFlight int, didDr
 		return
 	} else {
 		// Normal update to the limit
-		newLimit = l.estimatedLimit * gradient * float64(queueSize)
+		newLimit = l.estimatedLimit*gradient + float64(queueSize)
 	}
 
 	if newLimit < l.estimatedLimit {

--- a/limit/gradient_test.go
+++ b/limit/gradient_test.go
@@ -78,6 +78,6 @@ func TestGradientLimit(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			l.OnSample(int64(i*10+3030), 1, 5, false)
 		}
-		asrt.Equal(16, l.EstimatedLimit())
+		asrt.Equal(12, l.EstimatedLimit())
 	})
 }


### PR DESCRIPTION
I noticed that the gradient limit was very high when latency was increasing and the gradient was .5. This PR fixes what appears to have been a typo in the limit calculation, compared to the [concurrency-limits implementation](https://github.com/Netflix/concurrency-limits/blob/53eee348ab55bf1f0c2b6a8a7782642f741a1f0e/concurrency-limits-core/src/main/java/com/netflix/concurrency/limits/limit/GradientLimit.java#L302).