### PR TITLE
Fix debug log formatting in gradient2 limit

### DIFF
--- a/limit/gradient2.go
+++ b/limit/gradient2.go
@@ -222,7 +222,7 @@ func (l *Gradient2Limit) OnSample(startTime int64, rtt int64, inFlight int, didD
 	newLimit = math.Max(float64(l.minLimit), math.Min(float64(l.maxLimit), newLimit))
 
 	if newLimit != l.estimatedLimit && l.logger.IsDebugEnabled() {
-		l.logger.Debugf("new limit=%0.2f, shortRTT=%d ms, longRTT=%d ms, queueSize=%d, gradient=%0.2f",
+		l.logger.Debugf("new limit=%0.2f, shortRTT=%0.2f ms, longRTT=%0.2f ms, queueSize=%d, gradient=%0.2f",
 			newLimit, shortRTT/1e6, longRTT/1e6, queueSize, gradient)
 	}
 


### PR DESCRIPTION
The gradient2 limit currently outputs debug logging as:

```sh
2024/09/14 16:03:27 new limit=75.07, shortRTT=%!d(float64=472.985) ms, longRTT=%!d(float64=50.46388340039201) ms, queueSize=4, gradient=0.50
```

This PR formats the short and long RTT output as floats, ex:

```
2024/09/14 16:04:19 new limit=68.36, shortRTT=422.15 ms, longRTT=50.43 ms, queueSize=4, gradient=0.50
```