### PR TITLE
Allow the name prefix to be customised

### DIFF
--- a/core/dep.go
+++ b/core/dep.go
@@ -28,7 +28,7 @@ const (
 )
 
 // PrefixMetricWithName will prefix a given name with the metric name in the form "<name>.<metric>"
-func PrefixMetricWithName(metric, name string) string {
+var PrefixMetricWithName = func(metric, name string) string {
 	if name == "" {
 		name = "default"
 	}


### PR DESCRIPTION
Allow the name prefix of metrics to be customised by overriding the global variable.