### PR TITLE
fix: respect ordering from the configuration

### DIFF
--- a/limiter/queue_blocking.go
+++ b/limiter/queue_blocking.go
@@ -187,7 +187,6 @@ type QueueBlockingLimiter struct {
 	maxBacklogSize      uint64
 	maxBacklogTimeout   time.Duration
 	backlogEvictDoneCtx bool
-	ordering            QueueOrdering
 
 	backlog *queue
 	mu      sync.RWMutex
@@ -243,7 +242,7 @@ func NewQueueBlockingLimiterFromConfig(
 		backlogEvictDoneCtx: config.BacklogEvictDoneCtx,
 		backlog: &queue{
 			list:     list.New(),
-			ordering: OrderingFIFO,
+			ordering: config.Ordering,
 		},
 	}
 
@@ -342,5 +341,5 @@ func (l *QueueBlockingLimiter) Acquire(ctx context.Context) (core.Listener, bool
 
 func (l *QueueBlockingLimiter) String() string {
 	return fmt.Sprintf("QueueBlockingLimiter{delegate=%v, maxBacklogSize=%d, maxBacklogTimeout=%v, ordering=%v}",
-		l.delegate, l.maxBacklogSize, l.maxBacklogTimeout, l.ordering)
+		l.delegate, l.maxBacklogSize, l.maxBacklogTimeout, l.backlog.ordering)
 }

--- a/limiter/queue_blocking_test.go
+++ b/limiter/queue_blocking_test.go
@@ -343,6 +343,7 @@ func TestQueueBlockingLimiter_Lifo(t *testing.T) {
 			MaxBacklogTimeout: 0,
 			Ordering:          OrderingLIFO,
 		})
+		asrt.True(limiter.backlog.ordering == OrderingLIFO)
 		asrt.NotNil(limiter)
 		asrt.True(strings.Contains(limiter.String(), "QueueBlockingLimiter{delegate=DefaultLimiter{"))
 	})


### PR DESCRIPTION
This commit fixes an issue where `NewQueueBlockingLimiterWithDefaults` used a hardcoded queue ordering instead of respecting the configured ordering parameter.